### PR TITLE
Add ShareX opensource screenshot tool

### DIFF
--- a/profile.json
+++ b/profile.json
@@ -56,6 +56,7 @@
         {"name": "hashcat.fireeye"},
         {"name": "7zip"},
         {"name": "Greenshot.fireeye"},
+        {"name": "ShareX.fireeye"},
         {"name": "winscp.fireeye"},
         {"name": "keepass.fireeye"},
         {"name": "zap.fireeye"},


### PR DESCRIPTION
ShareX is actively developed comparing to Greenshot, which is outdated and development stalled. Opensource.
https://getsharex.com/
https://chocolatey.org/packages/sharex