### PR TITLE
hashcat is listed twice

### DIFF
--- a/profile.json
+++ b/profile.json
@@ -53,7 +53,6 @@
         {"name": "processhacker.flare"},
         {"name": "vlc.fireeye"},
         {"name": "yed.fireeye"},
-        {"name": "hashcat.fireeye"},
         {"name": "7zip"},
         {"name": "Greenshot.fireeye"},
         {"name": "winscp.fireeye"},


### PR DESCRIPTION
The entry for hashcat is list twice in the default profile