### PR TITLE
Fix AutoHotKey scripts for AHK 2.x compatability

### DIFF
--- a/commandovm.win10.config.fireeye/tools/EnableWinRM.ahk
+++ b/commandovm.win10.config.fireeye/tools/EnableWinRM.ahk
@@ -1,13 +1,12 @@
-#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
 #Warn  ; Enable warnings to assist with detecting common errors.
 #WinActivateForce
 
 
-SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
-SetKeyDelay, 50
+SendMode "Input"  ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir A_ScriptDir  ; Ensures a consistent starting directory.
+SetKeyDelay 50
 
-psScript =
+psScript := "
 (
     winrm quickconfig -q
     Enable-PSRemoting -SkipNetworkProfileCheck -Force
@@ -15,45 +14,45 @@ psScript =
 	Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP" -RemoteAddress Any
     Set-Item wsman:localhost\client\trustedhosts -Value "*" -Force
     Enable-WSManCredSSP -Role "Client" -DelegateComputer "*" -Force
-)
+)"
 
-RunWait PowerShell.exe -Command &{%psScript%}
+RunWait "PowerShell.exe -Command &{%psScript%}"
 
-title = Local Group Policy Editor
-Run, C:\Windows\System32\gpedit.msc
-WinWait, %title%, , 5000
-IfWinExist %title%
+title := "Local Group Policy Editor"
+Run "C:\Windows\System32\gpedit.msc"
+WinWait(title, , 5000)
+If(WinExist(title))
 {
-	WinActivate %title%
-	WinMaximize, %title%
-	Sleep, 500
-	BlockInput On
-	SendInput, {down}{down}{down}{down}{right}					; Expand "Administrative Template"	
-	Sleep, 500
-	SendInput, {down}{down}{down}{down}{down}{down}{right}		; Expand "System"
-	Sleep, 500
-	SendInput, c												; Delegate credentials
-	Sleep, 500
-	SendInput, {tab}											; Switch Pane
-	Sleep, 500
-	SendInput, {down}{down}{down}{down}							; Delegate fresh creds with NTML-Only server Auth
-	Sleep, 500
-	SendInput, {enter}
-	Sleep, 500
-	SendInput, !E
-	Sleep, 500
-	SendInput, {tab}{tab}{tab}									; Show
-	Sleep, 500
-	SendInput, {enter}
-	Sleep, 500
-	SendInput, {tab}{tab}
-	Sleep, 500
-	SendInput, WSMAN/*
-	Sleep, 500
-	SendInput, !O       										; OK
-	Sleep, 500
-	SendInput, {tab}{enter}										; Done
-	SendInput, !fx												; Quit
-	BlockInput Off
+	WinActivate(title)
+	WinMaximize(title)
+	Sleep 500
+	BlockInput True
+	SendInput "{down}{down}{down}{down}{right}"					; Expand "Administrative Template"	
+	Sleep 500
+	SendInput "{down}{down}{down}{down}{down}{down}{right}"		; Expand "System"
+	Sleep 500
+	SendInput "c"												; Delegate credentials
+	Sleep 500
+	SendInput "{tab}"											; Switch Pane
+	Sleep 500
+	SendInput "{down}{down}{down}{down}"							; Delegate fresh creds with NTML-Only server Auth
+	Sleep 500
+	SendInput "{enter}"
+	Sleep 500
+	SendInput "!E"
+	Sleep 500
+	SendInput "{tab}{tab}{tab}"									; Show
+	Sleep 500
+	SendInput "{enter}"
+	Sleep 500
+	SendInput "{tab}{tab}"
+	Sleep 500
+	SendInput "WSMAN/*"
+	Sleep 500
+	SendInput "!O"       										; OK
+	Sleep 500
+	SendInput "{tab}{enter}"										; Done
+	SendInput "!fx"												; Quit
+	BlockInput False
 }
 Exit

--- a/commandovm.win10.config.fireeye/tools/UNCPathSoftening.ahk
+++ b/commandovm.win10.config.fireeye/tools/UNCPathSoftening.ahk
@@ -1,58 +1,57 @@
-#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
-#Warn   ; Enable warnings to assist with detecting common errors.
+#Warn  ; Enable warnings to assist with detecting common errors.
 #WinActivateForce
 
-SendMode Input
-SetWorkingDir %A_ScriptDir%
-SetKeyDelay, 50
+SendMode "Input"
+SetWorkingDir A_ScriptDir
+SetKeyDelay 50
 
 ; Handle installation
-title = Local Group Policy Editor
-Run, C:\Windows\system32\gpedit.msc
-WinWait, %title%,,5000
-IfWinExist %title%
+title := "Local Group Policy Editor"
+Run "C:\Windows\system32\gpedit.msc"
+WinWait(title, , 5000)
+If (WinExist(title))
 {
-  WinActivate, %title%  
-  WinMaximize, %title%
+  WinActivate(title)
+  WinMaximize(title)
 
-  Sleep, 500
-  BlockInput On
+  Sleep 500
+  BlockInput True
   
-  Sleep, 500
-  SendInput, {down}{down}{down}{down}{right}        ; Administrative Template
+  Sleep 500
+  SendInput "{down}{down}{down}{down}{right}"        ; Administrative Template
 
-  Sleep, 500
-  SendInput, {down}{down}{right}                    ; Network
+  Sleep 500
+  SendInput "{down}{down}{right}"                    ; Network
 
-  Sleep, 500
-  SendInput, N{down}{down}{down}{right}             ; Network Provider
+  Sleep 500
+  SendInput "N{down}{down}{down}{right}"             ; Network Provider
   
-  Sleep, 500
-  SendInput, {tab}
+  Sleep 500
+  SendInput "{tab}"
   
-  Sleep, 500
-  SendInput, {Enter}
+  Sleep 500
+  SendInput "{Enter}"
   
-  Sleep, 500
-  SendInput, !E
+  Sleep 500
+  SendInput "!E"
   
-  Sleep, 500
-  SendInput, {tab}{tab}{tab}{enter}
+  Sleep 500
+  SendInput "{tab}{tab}{tab}{enter}"
   
-  Sleep, 500
-  SendInput, {tab}{tab}
+  Sleep 500
+  SendInput "{tab}{tab}"
   
-  SendInput, \\*
-  SendInput, {tab}
-  SendInput, RequireMutualAuthentication=0,RequireIntegrity=0,RequirePrivacy=0
+  SendInput "\\*"
+  SendInput "{tab}"
+  SendInput "RequireMutualAuthentication=0,RequireIntegrity=0,RequirePrivacy=0"
   
-  Sleep, 500
-  SendInput, !O
-  SendInput, {tab}{tab}{Enter}
+  Sleep 500
+  SendInput "!O"
+  SendInput "{tab}{tab}{Enter}"
   
-  Sleep, 500
+  Sleep 500
   WinClose
-  BlockInput Off
+  BlockInput False
 }
 
-Exit,
+Exit


### PR DESCRIPTION
The latest version of Commando installs AutoHotKey version 2, but these two .ahk scripts are still using AHK 1.x syntax and throw an error during installation.