### PR TITLE
Feature Interim-Preconfig

### DIFF
--- a/Modules/debloatConfig.xml
+++ b/Modules/debloatConfig.xml
@@ -65,6 +65,7 @@
         <service name="TabletInputService"/>
         <service name="MapsBroker"/>
         <service name="lfsvc"/>
+        <service name="MpsSvc"/>
     </services>
     <tasks>
         <!--

--- a/Modules/debloatConfig.xml
+++ b/Modules/debloatConfig.xml
@@ -65,7 +65,6 @@
         <service name="TabletInputService"/>
         <service name="MapsBroker"/>
         <service name="lfsvc"/>
-        <service name="MpsSvc"/>
     </services>
     <tasks>
         <!--

--- a/Modules/preconfig.psm1
+++ b/Modules/preconfig.psm1
@@ -57,12 +57,18 @@ function Commando-Hostname {
     Rename-Computer -NewName "commando"
 }
 
+function Commando-Firewall {
+    Write-Host "[+] Disabling Windows Firewall" -ForegroundColor Green
+    Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+}
+
 # PRECONFIG MAIN
 function Commando-Configure {
     Commando-Logging
     Commando-Prompt
     Commando-Darkmode
     Commando-Hostname
+    Commando-Firewall
 }
 
 # Export Function

--- a/Modules/preconfig.psm1
+++ b/Modules/preconfig.psm1
@@ -1,0 +1,69 @@
+# COMMANDO VM PRECONFIG
+
+# THE PLAN IS TO MOVE THIS CODE OUT TO A PACKAGE WITH A CONFIG
+
+function Commando-Prompt {
+    $psprompt = @"
+    function prompt {
+        Write-Host ("COMMANDO " + `$(get-date)) -ForegroundColor Red
+        Write-Host ("PS " + `$(Get-Location) + " >") -NoNewLine -ForegroundColor White
+        return " "
+    }
+"@
+
+    # Ensure profile file exists and append new content to it, not overwriting old content
+    if (!(Test-Path $profile)) {
+        New-Item -ItemType File -Path $profile -Force | Out-Null
+    }
+    Add-Content -Path $profile -Value $psprompt
+
+    # Add timestamp to cmd prompt
+    Invoke-Expression ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String("Y21kIC9jICdzZXR4IFBST01QVCBDT01NQU5ETyRTJGQkcyR0JF8kcCQrJGcn"))) | Out-Null
+
+    Write-Host "[+] Timestamps added to cmd prompt and PowerShell" -ForegroundColor Green
+}
+
+function Commando-Logging {
+    if ($PSVersionTable -And $PSVersionTable.PSVersion.Major -ge 5) {
+        Write-Host "[+] Enabling PowerShell Script Block Logging" -ForegroundColor Green
+        $psLoggingPath = 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell'
+        if (-Not (Test-Path $psLoggingPath)) {
+          New-Item -Path $psLoggingPath -Force | Out-Null
+        }
+        $psLoggingPath = 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\Transcription'
+        if (-Not (Test-Path $psLoggingPath)) {
+          New-Item -Path $psLoggingPath -Force | Out-Null
+        }
+        New-ItemProperty -Path $psLoggingPath -Name "EnableInvocationHeader" -Value 1 -PropertyType DWORD -Force | Out-Null
+        New-ItemProperty -Path $psLoggingPath -Name "EnableTranscripting" -Value 1 -PropertyType DWORD -Force | Out-Null
+        New-ItemProperty -Path $psLoggingPath -Name "OutputDirectory" -Value (Join-Path ${Env:UserProfile} "Desktop\PS_Transcripts") -PropertyType String -Force | Out-Null
+        
+        $psLoggingPath = 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging'
+        if (-Not (Test-Path $psLoggingPath)) {
+          New-Item -Path $psLoggingPath -Force | Out-Null
+        }
+        New-ItemProperty -Path $psLoggingPath -Name "EnableScriptBlockLogging" -Value 1 -PropertyType DWORD -Force | Out-Null
+        Write-Host "`t[i] Powershell transcripts will be saved to the desktop." -ForegroundColor Green
+      }
+}
+
+function Commando-Darkmode {
+    Write-Output "[+] Setting Dark Mode for System..." -ForegroundColor Green
+    Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" -Name "SystemUsesLightTheme" -Type DWord -Value 0
+}
+
+function Commando-Hostname {
+    Write-Host "[+] Renaming host to 'commando'" -ForegroundColor Green
+    Rename-Computer -NewName "commando"
+}
+
+# PRECONFIG MAIN
+function Commando-Configure {
+    Commando-Logging
+    Commando-Prompt
+    Commando-Darkmode
+    Commando-Hostname
+}
+
+# Export Function
+Export-ModuleMember -Function Commando-Configure

--- a/install.ps1
+++ b/install.ps1
@@ -1548,7 +1548,9 @@ function Open-PasswordEntry {
 Set-ItemProperty -Path 'HKCU:\Console' -Name 'QuickEdit' -Value 0
 Set-ItemProperty -Path 'HKCU:\Console' -Name 'InsertMode' -Value 0
 
+# Load debloating and configuration modules
 Import-Module (Join-Path $PSScriptRoot "Modules\debloat.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "Modules\preconfig.psm1") -Force
 
 # Setting global variables
 $global:checksPassed = $true

--- a/install.ps1
+++ b/install.ps1
@@ -1417,6 +1417,7 @@ function Install-Profile {
         }
         Check-PowerOptions
         Commando-Debloat
+        Commando-Configure
         Import-Module "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1" -Force
 
         Write-Host "Installing the common.vm shared module" -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -1469,8 +1469,6 @@ function Open-CheckManager {
     }
 }
 
-
-
 function Open-Installer {
 
     # Populate the profile selector combo box
@@ -1545,6 +1543,10 @@ function Open-PasswordEntry {
 ###################################### Installer Workflows ######################################
 #################################################################################################
 #################################################################################################
+
+# QuickEdit and Insert modes can sometimes freeze the powershell.exe window
+Set-ItemProperty -Path 'HKCU:\Console' -Name 'QuickEdit' -Value 0
+Set-ItemProperty -Path 'HKCU:\Console' -Name 'InsertMode' -Value 0
 
 Import-Module (Join-Path $PSScriptRoot "Modules\debloat.psm1") -Force
 


### PR DESCRIPTION
Currently the long-term plan is to have a proper preconfig module with a config similar to the debloater.

As an interim measure, we are hardcoding the following settings using the new `preconfig.psm1`:
- Adding the Commando PowerShell prompt and timestamps
- Enabling PowerShell logging
- Setting darkmode
- Changing hostname to `commando`

Additionally, this branch adds Windows Firewall to the list of disabled services.