### PR TITLE
Fix Win11ARM victim in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1457,7 +1457,7 @@ function Install-Profile {
         } elseif ($osVersion -eq "Win11ARM" -and -not $victim.IsPresent) {
             VM-Write-Log "INFO" "Windows 11 ARM detected, setting win11armconfig.xml for configuration file."
             Copy-Item $(Join-Path $configSource "win11armconfig.xml") $configPath -Force
-        } elseif ($osVersion -eq "Win11" -and -not $victim.IsPresent) {
+        } elseif ($osVersion -eq "Win11ARM" -and -not $victim.IsPresent) {
             VM-Write-Log "INFO" "Windows 11 ARM Victim detected, setting win11armvictimconfig.xml for configuration file."
             Copy-Item $(Join-Path $configSource "win11armvictimconfig.xml") $configPath -Force
         } else {


### PR DESCRIPTION
Fix typo that prevents Win11ARM victim to load the correct configuration.