### PR TITLE
Add ARM detection to the GUI

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1586,7 +1586,13 @@ Set-ItemProperty -Path 'HKCU:\Console' -Name 'InsertMode' -Value 0
 
 # Setting global variables
 $global:checksPassed = $true
-$global:selectedProfile = "Default"
+$osInfo = Get-ComputerInfo
+$osArchitecture = $osInfo.OSArchitecture
+if ($osArchitecture -match "ARM") {
+    $global:selectedProfile = "Default - ARM"
+} else{
+    $global:selectedProfile = "Default"
+}
 $global:credentials = ""
 
 ################################# GUI Workflow #################################


### PR DESCRIPTION
Prior to installing common.vm, adding some logic to detect system architecture (ripped straight from common.vm but didn't really see a way to use the common function before it was loaded).

There is no indication that there is an ARM profile on the GUI and it is unlikely someone wanting to install the defaults will manually select the "Default - ARM" profile without knowing of its existence.

Mostly a quality of life thing, but will also help eliminate confusion and ensure proper installation of default profiles.