### PR TITLE
Update README.md change from `cd ~/Downloads/commando-vm` to `cd ~/Downloads/commando-vm-main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To permanently disable Microsoft Defender:
 1. Download and extract the zip of the Commando-VM repo
 1. Run PowerShell as Administrator
 1. `Set-ExecutionPolicy Unrestricted -force`
-1. `cd ~/Downloads/commando-vm`
+1. `cd ~/Downloads/commando-vm-main`
 1. `Get-ChildItem .\ -Recurse | Unblock-File`
 1. `.\install.ps1` for a GUI install or `.\install.ps1 -cli` for command-line
 


### PR DESCRIPTION
In installation, change from `cd ~/Downloads/commando-vm` to `cd ~/Downloads/commando-vm-main` because when you download it, the folder is named commando-vm-main by default. You could name it commando-vm instead of commando-vm-main, but if you don't change the default it will be named commando-vm-main.